### PR TITLE
Add support for Confluence code block syntax highlighting (Fix #8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.borisdiakur</groupId>
     <artifactId>marked</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <organization>
         <name>Boris Diakur</name>
         <url>http://borisdiakur.com/</url>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-all</artifactId>
-            <version>0.18.5</version>
+            <version>0.19.4</version>
             <scope>compile</scope>
             <!-- important! -->
         </dependency>

--- a/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
+++ b/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
@@ -1,0 +1,104 @@
+package com.borisdiakur.marked;
+
+import com.vladsch.flexmark.Extension;
+import com.vladsch.flexmark.ast.FencedCodeBlock;
+import com.vladsch.flexmark.ast.IndentedCodeBlock;
+import com.vladsch.flexmark.ast.Node;
+import com.vladsch.flexmark.html.CustomNodeRenderer;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.html.HtmlWriter;
+import com.vladsch.flexmark.html.renderer.NodeRenderer;
+import com.vladsch.flexmark.html.renderer.NodeRendererContext;
+import com.vladsch.flexmark.html.renderer.NodeRendererFactory;
+import com.vladsch.flexmark.html.renderer.NodeRenderingHandler;
+import com.vladsch.flexmark.util.options.DataHolder;
+import com.vladsch.flexmark.util.options.MutableDataHolder;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererExtension {
+
+    static Extension create() {
+        return new ConfluenceCodeBlockExtension();
+    }
+
+    @Override
+    public void rendererOptions(MutableDataHolder mutableDataHolder) {
+
+    }
+
+    @Override
+    public void extend(HtmlRenderer.Builder rendererBuilder, String rendererType) {
+        rendererBuilder.nodeRendererFactory(new Factory());
+    }
+
+    public static class Factory implements NodeRendererFactory {
+
+        @Override
+        public NodeRenderer create(DataHolder options) {
+            return new ConfluenceCodeBlockNodeRenderer(options);
+        }
+    }
+
+    public static class ConfluenceCodeBlockNodeRenderer implements NodeRenderer {
+
+        static final String CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE = "<div class=\"code panel pdl conf-macro output-block\" data-hasbody=\"true\" data-macro-name=\"code\" style=\"border-width: 1px;\">" +
+                "<div class=\"codeContent panelContent pdl\">" +
+                "<pre class=\"syntaxhighlighter-pre\" data-syntaxhighlighter-params=\"brush: %s; gutter: false; theme: Confluence\" data-theme=\"Confluence\">";
+        static final String CONFLUENCE_CODE_BLOCK_HTML_CLOSE = "</pre></div></div>";
+
+        ConfluenceCodeBlockNodeRenderer(DataHolder options) {
+
+        }
+
+        @Override
+        public Set<NodeRenderingHandler<?>> getNodeRenderingHandlers() {
+            HashSet<NodeRenderingHandler<?>> handlers = new HashSet();
+            NodeRenderingHandler fencedCodeBlockHandler = new NodeRenderingHandler(FencedCodeBlock.class, new CustomNodeRenderer() {
+                @Override
+                public void render(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+                    ConfluenceCodeBlockNodeRenderer.this.renderFencedCodeBlock(node, context, htmlWriter);
+                }
+            });
+
+            NodeRenderingHandler indentedCodeBlockHandler = new NodeRenderingHandler(IndentedCodeBlock.class, new CustomNodeRenderer() {
+                @Override
+                public void render(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+                    ConfluenceCodeBlockNodeRenderer.this.renderIndentedCodeBlock(node, context, htmlWriter);
+                }
+            });
+
+            handlers.add(fencedCodeBlockHandler);
+            handlers.add(indentedCodeBlockHandler);
+
+            return handlers;
+        }
+
+        private void renderFencedCodeBlock(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+
+            FencedCodeBlock fencedCodeBlock = (FencedCodeBlock) node;
+
+            String language = fencedCodeBlock.getInfo().toString();
+            String code = fencedCodeBlock.getChildChars().toString();
+
+            write(code, language, htmlWriter);
+        }
+
+        private void renderIndentedCodeBlock(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+
+            IndentedCodeBlock indentedCodeBlock = (IndentedCodeBlock) node;
+            String code = indentedCodeBlock.getChars().toString();
+
+            write(code, "java", htmlWriter);
+        }
+
+        private void write(String code, String language, HtmlWriter htmlWriter) {
+            String htmlOpen = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, language);
+
+            htmlWriter.raw(htmlOpen);
+            htmlWriter.raw(code);
+            htmlWriter.raw(CONFLUENCE_CODE_BLOCK_HTML_CLOSE);
+        }
+    }
+}

--- a/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
+++ b/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
@@ -80,6 +80,10 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
             FencedCodeBlock fencedCodeBlock = (FencedCodeBlock) node;
 
             String language = fencedCodeBlock.getInfo().toString();
+            if (language.isEmpty()) {
+                // confluence defaults to java
+                language = "java";
+            }
             String code = fencedCodeBlock.getChildChars().toString();
 
             write(code, language, htmlWriter);
@@ -90,6 +94,7 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
             IndentedCodeBlock indentedCodeBlock = (IndentedCodeBlock) node;
             String code = indentedCodeBlock.getChars().toString();
 
+            // confluence defaults to java
             write(code, "java", htmlWriter);
         }
 

--- a/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
+++ b/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
@@ -54,17 +54,17 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
 
         @Override
         public Set<NodeRenderingHandler<?>> getNodeRenderingHandlers() {
-            HashSet<NodeRenderingHandler<?>> handlers = new HashSet();
-            NodeRenderingHandler fencedCodeBlockHandler = new NodeRenderingHandler(FencedCodeBlock.class, new CustomNodeRenderer() {
+            HashSet<NodeRenderingHandler<?>> handlers = new HashSet<NodeRenderingHandler<?>>();
+            NodeRenderingHandler<FencedCodeBlock> fencedCodeBlockHandler = new NodeRenderingHandler<FencedCodeBlock>(FencedCodeBlock.class, new CustomNodeRenderer<FencedCodeBlock>() {
                 @Override
-                public void render(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+                public void render(FencedCodeBlock node, NodeRendererContext context, HtmlWriter htmlWriter) {
                     ConfluenceCodeBlockNodeRenderer.this.renderFencedCodeBlock(node, context, htmlWriter);
                 }
             });
 
-            NodeRenderingHandler indentedCodeBlockHandler = new NodeRenderingHandler(IndentedCodeBlock.class, new CustomNodeRenderer() {
+            NodeRenderingHandler<IndentedCodeBlock> indentedCodeBlockHandler = new NodeRenderingHandler<IndentedCodeBlock>(IndentedCodeBlock.class, new CustomNodeRenderer<IndentedCodeBlock>() {
                 @Override
-                public void render(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
+                public void render(IndentedCodeBlock node, NodeRendererContext context, HtmlWriter htmlWriter) {
                     ConfluenceCodeBlockNodeRenderer.this.renderIndentedCodeBlock(node, context, htmlWriter);
                 }
             });
@@ -75,10 +75,7 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
             return handlers;
         }
 
-        private void renderFencedCodeBlock(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
-
-            FencedCodeBlock fencedCodeBlock = (FencedCodeBlock) node;
-
+        private void renderFencedCodeBlock(FencedCodeBlock fencedCodeBlock, NodeRendererContext context, HtmlWriter htmlWriter) {
             String language = fencedCodeBlock.getInfo().toString();
             if (language.isEmpty()) {
                 // confluence defaults to java
@@ -89,9 +86,7 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
             write(code, language, htmlWriter);
         }
 
-        private void renderIndentedCodeBlock(Node node, NodeRendererContext context, HtmlWriter htmlWriter) {
-
-            IndentedCodeBlock indentedCodeBlock = (IndentedCodeBlock) node;
+        private void renderIndentedCodeBlock(IndentedCodeBlock indentedCodeBlock, NodeRendererContext context, HtmlWriter htmlWriter) {
             String code = indentedCodeBlock.getChars().toString();
 
             // confluence defaults to java

--- a/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
+++ b/src/main/java/com/borisdiakur/marked/ConfluenceCodeBlockExtension.java
@@ -3,7 +3,6 @@ package com.borisdiakur.marked;
 import com.vladsch.flexmark.Extension;
 import com.vladsch.flexmark.ast.FencedCodeBlock;
 import com.vladsch.flexmark.ast.IndentedCodeBlock;
-import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.html.CustomNodeRenderer;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.html.HtmlWriter;
@@ -13,6 +12,7 @@ import com.vladsch.flexmark.html.renderer.NodeRendererFactory;
 import com.vladsch.flexmark.html.renderer.NodeRenderingHandler;
 import com.vladsch.flexmark.util.options.DataHolder;
 import com.vladsch.flexmark.util.options.MutableDataHolder;
+import com.vladsch.flexmark.util.sequence.BasedSequence;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -87,7 +87,13 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
         }
 
         private void renderIndentedCodeBlock(IndentedCodeBlock indentedCodeBlock, NodeRendererContext context, HtmlWriter htmlWriter) {
-            String code = indentedCodeBlock.getChars().toString();
+
+            StringBuilder builder = new StringBuilder();
+            for (BasedSequence line : indentedCodeBlock.getContentLines()) {
+                builder.append(line.toString());
+            }
+
+            String code = builder.toString();
 
             // confluence defaults to java
             write(code, "java", htmlWriter);
@@ -97,7 +103,9 @@ public class ConfluenceCodeBlockExtension implements HtmlRenderer.HtmlRendererEx
             String htmlOpen = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, language);
 
             htmlWriter.raw(htmlOpen);
+            htmlWriter.openPre();
             htmlWriter.raw(code);
+            htmlWriter.closePre();
             htmlWriter.raw(CONFLUENCE_CODE_BLOCK_HTML_CLOSE);
         }
     }

--- a/src/main/java/com/borisdiakur/marked/MarkedMacro.java
+++ b/src/main/java/com/borisdiakur/marked/MarkedMacro.java
@@ -81,13 +81,18 @@ public class MarkedMacro extends BaseMacro implements Macro {
             return "Cannot find valid resource.";
         }
 
+        String markdown = getpage(url);
+        return convertToHtml(markdown);
+    }
+
+    String convertToHtml(String markdown) {
         MutableDataSet options = new MutableDataSet();
         options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create()));
         Parser parser = Parser.builder(options).build();
         HtmlRenderer renderer = HtmlRenderer.builder(options).build();
-
-        return renderer.render(parser.parse(getpage(url)));
+        return renderer.render(parser.parse(markdown));
     }
+
 
     @Override
     public boolean hasBody() {

--- a/src/main/java/com/borisdiakur/marked/MarkedMacro.java
+++ b/src/main/java/com/borisdiakur/marked/MarkedMacro.java
@@ -24,8 +24,7 @@ import java.util.Map;
 
 public class MarkedMacro extends BaseMacro implements Macro {
 
-    private String getpage(URL url) {
-
+    private String fetchPage(URL url) {
         try {
             // try opening the URL
             URLConnection urlConnection = url.openConnection();
@@ -79,7 +78,7 @@ public class MarkedMacro extends BaseMacro implements Macro {
             return "Cannot find valid resource.";
         }
 
-        String markdown = getpage(url);
+        String markdown = fetchPage(url);
         return convertToHtml(markdown);
     }
 

--- a/src/main/java/com/borisdiakur/marked/MarkedMacro.java
+++ b/src/main/java/com/borisdiakur/marked/MarkedMacro.java
@@ -57,8 +57,6 @@ public class MarkedMacro extends BaseMacro implements Macro {
         }
     }
 
-    public MarkedMacro() {}
-
     @Override
     public BodyType getBodyType() {
         return BodyType.NONE;
@@ -87,7 +85,7 @@ public class MarkedMacro extends BaseMacro implements Macro {
 
     String convertToHtml(String markdown) {
         MutableDataSet options = new MutableDataSet();
-        options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create()));
+        options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create(), ConfluenceCodeBlockExtension.create()));
         Parser parser = Parser.builder(options).build();
         HtmlRenderer renderer = HtmlRenderer.builder(options).build();
         return renderer.render(parser.parse(markdown));

--- a/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
+++ b/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
@@ -1,0 +1,29 @@
+package com.borisdiakur.marked;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MarkedMacroTest {
+
+    private MarkedMacro markedMacro;
+
+    @Before
+    public void setUp() {
+        markedMacro = new MarkedMacro();
+    }
+
+    @Test
+    public void convertsCodeFence() {
+        // given a markdown containing code fence
+        String markdown = "```\nfoobar\n```";
+
+        // when converting markdown to html
+        String html = markedMacro.convertToHtml(markdown);
+
+        // then code tag is wrapped in table
+        assertEquals("foo", html);
+    }
+
+}

--- a/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
+++ b/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
@@ -50,4 +50,21 @@ public class MarkedMacroTest {
         assertEquals(expectedHtml, html);
     }
 
+    @Test
+    public void convertsFencedCodeBlockToConfluenceCodeBlockWhenNoLanguageIsSpecified() {
+        // given a markdown containing code fence
+        String markdown = "```\n" +
+                "System.out.println(\"foobar\")\n" +
+                "int x = 5\n" +
+                "```";
+
+        // when converting markdown to html
+        String html = markedMacro.convertToHtml(markdown);
+
+        // then code tag is wrapped in confluence blocks
+        String expectedHtml = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, "java") + "System.out.println(\"foobar\")\n" +
+                "int x = 5\n" + CONFLUENCE_CODE_BLOCK_HTML_CLOSE + "\n";
+
+        assertEquals(expectedHtml, html);
+    }
 }

--- a/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
+++ b/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
@@ -3,6 +3,8 @@ package com.borisdiakur.marked;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.borisdiakur.marked.ConfluenceCodeBlockExtension.ConfluenceCodeBlockNodeRenderer.CONFLUENCE_CODE_BLOCK_HTML_CLOSE;
+import static com.borisdiakur.marked.ConfluenceCodeBlockExtension.ConfluenceCodeBlockNodeRenderer.CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE;
 import static org.junit.Assert.*;
 
 public class MarkedMacroTest {
@@ -15,15 +17,37 @@ public class MarkedMacroTest {
     }
 
     @Test
-    public void convertsCodeFence() {
-        // given a markdown containing code fence
-        String markdown = "```\nfoobar\n```";
+    public void convertsIndentedCodeBlockToConfluenceCodeBlock() {
+        // given a markdown containing indented code
+        String markdown = "    System.out.println(\"foobar\");\n" +
+                "    int x = 5;";
 
         // when converting markdown to html
         String html = markedMacro.convertToHtml(markdown);
 
-        // then code tag is wrapped in table
-        assertEquals("foo", html);
+        // then code tag is wrapped in confluence blocks
+        String expectedHtml = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, "java") + "System.out.println(\"foobar\");\n" +
+                "int x = 5;" + CONFLUENCE_CODE_BLOCK_HTML_CLOSE + "\n";
+
+        assertEquals(expectedHtml, html);
+    }
+
+    @Test
+    public void convertsFencedCodeBlockToConfluenceCodeBlock() {
+        // given a markdown containing code fence
+        String markdown = "```groovy\n" +
+                "System.out.println(\"foobar\")\n" +
+                "int x = 5\n" +
+                "```";
+
+        // when converting markdown to html
+        String html = markedMacro.convertToHtml(markdown);
+
+        // then code tag is wrapped in confluence blocks
+        String expectedHtml = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, "groovy") + "System.out.println(\"foobar\")\n" +
+                "int x = 5\n" + CONFLUENCE_CODE_BLOCK_HTML_CLOSE + "\n";
+
+        assertEquals(expectedHtml, html);
     }
 
 }

--- a/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
+++ b/src/test/java/com/borisdiakur/marked/MarkedMacroTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import static com.borisdiakur.marked.ConfluenceCodeBlockExtension.ConfluenceCodeBlockNodeRenderer.CONFLUENCE_CODE_BLOCK_HTML_CLOSE;
 import static com.borisdiakur.marked.ConfluenceCodeBlockExtension.ConfluenceCodeBlockNodeRenderer.CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class MarkedMacroTest {
 
@@ -20,14 +20,14 @@ public class MarkedMacroTest {
     public void convertsIndentedCodeBlockToConfluenceCodeBlock() {
         // given a markdown containing indented code
         String markdown = "    System.out.println(\"foobar\");\n" +
-                "    int x = 5;";
+                "    int x = 5;\n" + "        int y = 10;\n";
 
         // when converting markdown to html
         String html = markedMacro.convertToHtml(markdown);
 
         // then code tag is wrapped in confluence blocks
         String expectedHtml = String.format(CONFLUENCE_CODE_BLOCK_HTML_OPEN_TEMPLATE, "java") + "System.out.println(\"foobar\");\n" +
-                "int x = 5;" + CONFLUENCE_CODE_BLOCK_HTML_CLOSE + "\n";
+                "int x = 5;\n" + "    int y = 10;\n" + CONFLUENCE_CODE_BLOCK_HTML_CLOSE + "\n";
 
         assertEquals(expectedHtml, html);
     }
@@ -67,4 +67,83 @@ public class MarkedMacroTest {
 
         assertEquals(expectedHtml, html);
     }
+
+    @Test
+    public void doesNotStripIndentationInsideFencedCodeBlock() {
+        // given markdown containing code fence with code indented with spaces
+        String markdown = "\n" +
+                "```java\n" +
+                "package com.vladsch.flexmark.samples;\n" +
+                "\n" +
+                "import com.vladsch.flexmark.ast.Node;\n" +
+                "import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;\n" +
+                "import com.vladsch.flexmark.ext.tables.TablesExtension;\n" +
+                "import com.vladsch.flexmark.html.HtmlRenderer;\n" +
+                "import com.vladsch.flexmark.parser.Parser;\n" +
+                "import com.vladsch.flexmark.util.options.MutableDataSet;\n" +
+                "\n" +
+                "import java.util.Arrays;\n" +
+                "\n" +
+                "public class BasicSample {\n" +
+                "    public static void main(String[] args) {\n" +
+                "        MutableDataSet options = new MutableDataSet();\n" +
+                "\n" +
+                "        // uncomment to set optional extensions\n" +
+                "        //options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create()));\n" +
+                "\n" +
+                "        // uncomment to convert soft-breaks to hard breaks\n" +
+                "        //options.set(HtmlRenderer.SOFT_BREAK, \"<br />\\n\");\n" +
+                "\n" +
+                "        Parser parser = Parser.builder(options).build();\n" +
+                "        HtmlRenderer renderer = HtmlRenderer.builder(options).build();\n" +
+                "\n" +
+                "        // You can re-use parser and renderer instances\n" +
+                "        Node document = parser.parse(\"This is *Sparta*\");\n" +
+                "        String html = renderer.render(document);  // \"<p>This is <em>Sparta</em></p>\\n\"\n" +
+                "        System.out.println(html);\n" +
+                "    }\n" +
+                "}\n" +
+                "```";
+
+        // when converting markdown to html
+        String html = markedMacro.convertToHtml(markdown);
+
+        // spaces are not stripped
+        String expectedHtml = "<div class=\"code panel pdl conf-macro output-block\" data-hasbody=\"true\" data-macro-name=\"code\" style=\"border-width: 1px;\"><div class=\"codeContent panelContent pdl\"><pre class=\"syntaxhighlighter-pre\" data-syntaxhighlighter-params=\"brush: java; gutter: false; theme: Confluence\" data-theme=\"Confluence\">package com.vladsch.flexmark.samples;\n" +
+                "\n" +
+                "import com.vladsch.flexmark.ast.Node;\n" +
+                "import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;\n" +
+                "import com.vladsch.flexmark.ext.tables.TablesExtension;\n" +
+                "import com.vladsch.flexmark.html.HtmlRenderer;\n" +
+                "import com.vladsch.flexmark.parser.Parser;\n" +
+                "import com.vladsch.flexmark.util.options.MutableDataSet;\n" +
+                "\n" +
+                "import java.util.Arrays;\n" +
+                "\n" +
+                "public class BasicSample {\n" +
+                "    public static void main(String[] args) {\n" +
+                "        MutableDataSet options = new MutableDataSet();\n" +
+                "\n" +
+                "        // uncomment to set optional extensions\n" +
+                "        //options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create()));\n" +
+                "\n" +
+                "        // uncomment to convert soft-breaks to hard breaks\n" +
+                "        //options.set(HtmlRenderer.SOFT_BREAK, \"<br />\\n\");\n" +
+                "\n" +
+                "        Parser parser = Parser.builder(options).build();\n" +
+                "        HtmlRenderer renderer = HtmlRenderer.builder(options).build();\n" +
+                "\n" +
+                "        // You can re-use parser and renderer instances\n" +
+                "        Node document = parser.parse(\"This is *Sparta*\");\n" +
+                "        String html = renderer.render(document);  // \"<p>This is <em>Sparta</em></p>\\n\"\n" +
+                "        System.out.println(html);\n" +
+                "    }\n" +
+                "}\n" +
+                "</pre></div></div>\n";
+
+
+        assertEquals(expectedHtml, html);
+    }
+
+
 }


### PR DESCRIPTION
Adds a flexmark `ConfluenceCodeBlockExtension`, which wraps the code blocks with Confluence specific HTML code. Works with fenced and intended code blocks and supports specifiying the language in fenced code blocks.

Also adds a unit tests for `ConfluenceCodeBlockExtension` and refactors `MarkedMacro` class to be easier testable.

This fixes #8 