### PR TITLE
Support for Bitbucket on authenticated resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+Support for Bitbucket on authenticated resources.
+
 ## 1.1.2
 
 Support release for Confluence 6.1.1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ or from [GitHub](https://github.com/borisdiakur/marked).
 ## Usage
 
 1. Select _marked_ in the _Select macro_ dialog.
-2. Insert the URL of your raw markdown resource in the input field labeled with _URL_.
+2. Select a connector type between Bitbucket Url Api Reference Markdown (Json Object) or any remote HTTP(S) plain text markdown.   
+3. Insert the URL of resource in the input field labeled with _URL_.
+4. If your resource requires HTTP Basic authentication, provide the user and password or leave them blank.
 3. Preview the rendered result by clicking on _Preview_.
 4. Insert the rendered content by clicking on _Insert_. You can now preview and save the document.
 
@@ -35,8 +37,7 @@ or from [GitHub](https://github.com/borisdiakur/marked).
 
 ### 1. Can _marked_ access resources which reside in a private repository?
 
-When working with repositories which require authentication you'll might need to use the associated API
-in order to access those files.
+When working with repositories which requires authentication you'll might need to use the associated API in order to access those files.
 For example you'll __not__ be able to access a file on a private [__GitLab__](https://about.gitlab.com/) instance
 using the following URL:
 
@@ -53,10 +54,15 @@ In order to get the correct URL you would do the following:
 2. Get a list of files for a given project id: `https://gitlab.yourdomain.com/api/v3/projects/your-project-id/repository/tree?private_token=your-private-token`
 3. Get the raw file content for a given file id: `https://gitlab.yourdomain.com/api/v3/projects/your-project-id/repository/raw_blobs/your-file-id?private_token=your-private-token`
 
-__Note__: When working with another repository management system such as [Bitbucket](https://bitbucket.org/) or whatnot
-you will have to comply with the API given.
 
-_marked_ also supports basic auth.
+If you are using Bitbucket Respository [Bitbucket](https://bitbucket.org/) you can not access a resource in plain text through the REST API. The rest API provides the resource as a Json Object. In this situation you have to choose BitbucketUrlApiReferenceMarkdown as connector type which automatically will parse the Json Object to plain text.
+
+This is a bitbucket rest API URL: http[s]://[bicket-servser]:[port]/rest/api/1.0/users/[user]/repos/[repo]/browse/[path-to-markdown]
+
+You will have to provide HTTP Basic Authentication as well. 
+
+_marked_ supports basic authentication  through the URL user info: http://user:password@rest-of-the-url or through the fields provided in the macro configuration. The second one is the recommended approach to avoid show the clear password in the Confluence Space when an error arises.  
+
 
 ### 2. I get a PKIX path building failed error. What's that? 
 

--- a/src/main/java/com/borisdiakur/marked/MarkedMacro.java
+++ b/src/main/java/com/borisdiakur/marked/MarkedMacro.java
@@ -8,6 +8,8 @@ import com.atlassian.renderer.RenderContext;
 import com.atlassian.renderer.v2.RenderMode;
 import com.atlassian.renderer.v2.macro.BaseMacro;
 import com.atlassian.renderer.v2.macro.MacroException;
+import com.google.gson.Gson;
+import com.google.gson.internal.StringMap;
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
@@ -19,94 +21,126 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
 public class MarkedMacro extends BaseMacro implements Macro {
 
-    private String fetchPage(URL url) {
-        try {
-            // try opening the URL
-            URLConnection urlConnection = url.openConnection();
+	private String fetchPage(URL url, String user, String password) {
+		try {
+			// try opening the URL
+			URLConnection urlConnection = url.openConnection();
 
-            // basic auth
-            if (url.getUserInfo() != null) {
-                String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(url.getUserInfo().getBytes());
-                urlConnection.setRequestProperty("Authorization", basicAuth);
-            }
+			// basic auth
+			if (url.getUserInfo() != null) {
+				String basicAuth = "Basic "
+						+ javax.xml.bind.DatatypeConverter.printBase64Binary(url.getUserInfo().getBytes());
+				urlConnection.setRequestProperty("Authorization", basicAuth);
+			}
+			if (user != null && password != null) {
+				String basicAuth = "Basic "
+						+ javax.xml.bind.DatatypeConverter.printBase64Binary((user + ":" + password).getBytes());
+				urlConnection.setRequestProperty("Authorization", basicAuth);
+			}
+			InputStream urlStream = urlConnection.getInputStream();
+			byte buffer[] = new byte[1000];
+			int numRead = urlStream.read(buffer);
+			String content = new String(buffer, 0, numRead);
 
-            InputStream urlStream = urlConnection.getInputStream();
-            byte buffer[] = new byte[1000];
-            int numRead = urlStream.read(buffer);
-            String content = new String(buffer, 0, numRead);
+			int MAX_PAGE_SIZE = Integer.MAX_VALUE;
+			while ((numRead != -1) && (content.length() < MAX_PAGE_SIZE)) {
+				numRead = urlStream.read(buffer);
+				if (numRead != -1) {
+					String newContent = new String(buffer, 0, numRead);
+					content += newContent;
+				}
+			}
+			return content;
+		} catch (IOException ioe) {
+			return "Cannot read resource.\n".concat(ioe.getLocalizedMessage());
+		} catch (IndexOutOfBoundsException iaobe) {
+			return "Resource is too large.";
+		}
+	}
 
-            int MAX_PAGE_SIZE = Integer.MAX_VALUE;
-            while ((numRead != -1) && (content.length() < MAX_PAGE_SIZE)) {
-                numRead = urlStream.read(buffer);
-                if (numRead != -1) {
-                    String newContent = new String(buffer, 0, numRead);
-                    content += newContent;
-                }
-            }
-            return content;
-        } catch (IOException ioe) {
-            return "Cannot read resource.\n".concat(ioe.getLocalizedMessage());
-        } catch (IndexOutOfBoundsException iaobe) {
-            return "Resource is too large.";
-        }
-    }
+	@Override
+	public BodyType getBodyType() {
+		return BodyType.NONE;
+	}
 
-    @Override
-    public BodyType getBodyType() {
-        return BodyType.NONE;
-    }
+	@Override
+	public OutputType getOutputType() {
+		return OutputType.BLOCK;
+	}
 
-    @Override
-    public OutputType getOutputType() {
-        return OutputType.BLOCK;
-    }
+	@Override
+	public String execute(Map<String, String> parameters, String bodyContent, ConversionContext conversionContext)
+			throws MacroExecutionException {
+		URL urlObject = null;
+		String url = parameters.get("URL");
+		String markdown = null;
+		String connectorType = parameters.get("ConnectorType");
+		String httpBasicUser = parameters.get("HttpBasicUser");
+		String httpBasicPassword = parameters.get("HttpBasicPassword");
 
-    @Override
-    public String execute(Map<String, String> parameters, String bodyContent, ConversionContext conversionContext) throws MacroExecutionException {
-        URL url;
-        if (parameters.get("URL") == null) {
-            return "";
-        }
-        try {
-            url = new URL(parameters.get("URL"));
-        } catch (MalformedURLException e) {
-            return "Cannot find valid resource.";
-        }
+		if (url == null) {
+			return "";
+		}
 
-        String markdown = fetchPage(url);
-        return convertToHtml(markdown);
-    }
+		try {
+			urlObject = new URL(url);
+		} catch (MalformedURLException e) {
+			return "Cannot find valid resource.";
+		}
+		String content = fetchPage(urlObject, httpBasicUser, httpBasicPassword);
 
-    String convertToHtml(String markdown) {
-        MutableDataSet options = new MutableDataSet();
-        options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create(), ConfluenceCodeBlockExtension.create()));
-        Parser parser = Parser.builder(options).build();
-        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
-        return renderer.render(parser.parse(markdown));
-    }
+		if (connectorType.equals("BitbucketUrlApiReferenceMarkdown")) {
+			markdown = this.parseBitbucketJson(content);
+		} else {
+			markdown = content;
+		}
+		return convertToHtml(markdown);
+	}
 
+	@SuppressWarnings("rawtypes")
+	String parseBitbucketJson(String json) {
+		StringBuilder sb = new StringBuilder();
+		Map map = new Gson().fromJson(json, Map.class);
+		ArrayList lines = (ArrayList) map.get("lines");
+		for (Object line : lines) {
+			StringMap m = (StringMap) line;
+			sb.append(m.get("text"));
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
 
-    @Override
-    public boolean hasBody() {
-        return true;
-    }
+	String convertToHtml(String markdown) {
+		MutableDataSet options = new MutableDataSet();
+		options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), StrikethroughExtension.create(),
+				ConfluenceCodeBlockExtension.create()));
+		Parser parser = Parser.builder(options).build();
+		HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+		return renderer.render(parser.parse(markdown));
+	}
 
-    @Override
-    public RenderMode getBodyRenderMode() {
-        return RenderMode.NO_RENDER;
-    }
+	@Override
+	public boolean hasBody() {
+		return true;
+	}
 
-    @Override
-    public String execute(Map map, String s, RenderContext renderContext) throws MacroException {
-        try {
-            return execute(map, s, new DefaultConversionContext(renderContext));
-        } catch (MacroExecutionException e) {
-            throw new MacroException(e.getMessage(), e);
-        }
-    }
+	@Override
+	public RenderMode getBodyRenderMode() {
+		return RenderMode.NO_RENDER;
+	}
+
+	@Override
+	public String execute(Map map, String s, RenderContext renderContext) throws MacroException {
+		try {
+			return execute(map, s, new DefaultConversionContext(renderContext));
+		} catch (MacroExecutionException e) {
+			throw new MacroException(e.getMessage(), e);
+		}
+	}
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -1,31 +1,44 @@
-<atlassian-plugin key="${project.groupId}.${project.artifactId}" name="${project.name}" plugins-version="2">
-    <plugin-info>
-        <description>${project.description}</description>
-        <version>${project.version}</version>
-        <vendor name="${project.organization.name}" url="${project.organization.url}" />
-        <param name="plugin-icon">images/pluginIcon.png</param>
-        <param name="plugin-logo">images/pluginLogo.png</param>
-        <param name="atlassian-data-center-compatible">true</param>
-    </plugin-info>
+<atlassian-plugin key="${project.groupId}.${project.artifactId}"
+	name="${project.name}" plugins-version="2">
+	<plugin-info>
+		<description>${project.description}</description>
+		<version>${project.version}</version>
+		<vendor name="${project.organization.name}" url="${project.organization.url}" />
+		<param name="plugin-icon">images/pluginIcon.png</param>
+		<param name="plugin-logo">images/pluginLogo.png</param>
+		<param name="atlassian-data-center-compatible">true</param>
+	</plugin-info>
 
-    <xhtml-macro name="marked"
-                 key="marked"
-                 class="com.borisdiakur.marked.MarkedMacro"
-                 icon="/download/resources/${project.groupId}.${project.artifactId}/images/pluginLogo.png"
-                 documentation-url="https://github.com/borisdiakur/marked">
-        <category name="formatting"/>
+	<xhtml-macro name="marked" key="marked"
+		class="com.borisdiakur.marked.MarkedMacro"
+		icon="/download/resources/${project.groupId}.${project.artifactId}/images/pluginLogo.png"
+		documentation-url="https://github.com/borisdiakur/marked">
+		<category name="formatting" />
 
-        <device-type>mobile</device-type>
+		<device-type>mobile</device-type>
 
-        <description>${project.description}</description>
+		<description>${project.description}</description>
 
-        <parameters>
-            <parameter name="URL" type="string" default ="">
-                <option key="showNameInPlaceholder" value="false" />
-                <option key="showValueInPlaceholder" value="true" />
-            </parameter>
-        </parameters>
-    </xhtml-macro>
+		<parameters>
+			<parameter name="ConnectorType" type="enum">
+				<value name="BitbucketUrlApiReferenceMarkdown" />
+				<value name="PlainTextMarkdown" />
+			</parameter>
+			<parameter name="URL" type="string" default="">
+				<option key="showNameInPlaceholder" value="false" />
+				<option key="showValueInPlaceholder" value="true" />
+			</parameter>			
+			<parameter name="HttpBasicUser" type="string">
+				<option key="showNameInPlaceholder" value="false" />
+				<option key="showValueInPlaceholder" value="true" />
+			</parameter>
+			<parameter name="HttpBasicPassword" type="string">
+				<option key="showNameInPlaceholder" value="false" />
+				<option key="showValueInPlaceholder" value="false" />
+			</parameter>
+		</parameters>
+	</xhtml-macro>
 
-    <resource type="download" name="images/" key="images" location="images/"/>
+	<resource type="download" name="images/" key="images"
+		location="images/" />
 </atlassian-plugin>


### PR DESCRIPTION
Hi Boris, I could not get a masked field in the plugin parameters, if you know how to do that it would be great. However it is better to have HTTPBasic auth info in parameters instead of URL because when Confluence can not connect for any reason shows the URL (including user and password) in the Confluence spaces to any reader.

It is necessary to upgrade the image in the README. I let you do that.

Thank you