### PR TITLE
Proposed fix for issue #4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.borisdiakur</groupId>
     <artifactId>marked</artifactId>
-    <version>1.2.15</version>
+    <version>1.2.16</version>
     <organization>
         <name>Boris Diakur</name>
         <url>http://borisdiakur.com/</url>
@@ -78,6 +78,7 @@
         </plugins>
     </build>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluence.version>7.6.1</confluence.version>
         <confluence.data.version>7.6.1</confluence.data.version>
         <amps.version>8.0.1</amps.version>

--- a/src/main/java/com/borisdiakur/marked/MarkedMacro.java
+++ b/src/main/java/com/borisdiakur/marked/MarkedMacro.java
@@ -15,9 +15,12 @@ import com.vladsch.flexmark.html.HtmlRenderer.Builder;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.options.MutableDataSet;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -38,13 +41,16 @@ public class MarkedMacro extends BaseMacro implements Macro {
             }
 
             InputStream urlStream = urlConnection.getInputStream();
-            byte buffer[] = new byte[1000];
-            int numRead = urlStream.read(buffer);
+            InputStreamReader inputStreamReader = new InputStreamReader(urlStream, StandardCharsets.UTF_8);
+            BufferedReader bufReader = new BufferedReader(inputStreamReader);
+
+            char buffer[] = new char[1000];
+            int numRead = bufReader.read(buffer);
             String content = new String(buffer, 0, numRead);
 
             int MAX_PAGE_SIZE = Integer.MAX_VALUE;
             while ((numRead != -1) && (content.length() < MAX_PAGE_SIZE)) {
-                numRead = urlStream.read(buffer);
+                numRead = bufReader.read(buffer);
                 if (numRead != -1) {
                     String newContent = new String(buffer, 0, numRead);
                     content += newContent;


### PR DESCRIPTION
This fixes utf-8 on one of our older system and confluence, that does not manage to do the right thing when fetching a markdown from bitbucket. This means also that the markdown files has to be proper utf-8, but I think that's where we aim? 
(Otherwise we'll need to parse and handle headers like ContentType, which makes it more involved)

Also silence a build warning by adding a line in the pom.xml